### PR TITLE
Fix acquire spelling in logging messages

### DIFF
--- a/commandHandler.go
+++ b/commandHandler.go
@@ -72,7 +72,7 @@ var commandHandlers = map[string]func(s *discordgo.Session, i *discordgo.Interac
 			Data: &discordgo.InteractionResponseData{Flags: discordgo.MessageFlagsEphemeral}})
 		conn, err := pool.Acquire(context.Background())
 		if err != nil {
-			log.Error("Could not aquire db connection from pool", "error", err)
+			log.Error("Could not acquire db connection from pool", "error", err)
 			return
 		}
 		defer conn.Release()
@@ -166,7 +166,7 @@ var commandHandlers = map[string]func(s *discordgo.Session, i *discordgo.Interac
 		}
 		conn, err := pool.Acquire(context.Background())
 		if err != nil {
-			log.Error("Could not aquire db connection from pool", "error", err)
+			log.Error("Could not acquire db connection from pool", "error", err)
 			return
 		}
 		defer conn.Release()
@@ -212,7 +212,7 @@ var commandHandlers = map[string]func(s *discordgo.Session, i *discordgo.Interac
 		opt := GetOptions(i.ApplicationCommandData().Options)
 		conn, err := pool.Acquire(context.Background())
 		if err != nil {
-			log.Error("Could not aquire db connection from pool", "error", err)
+			log.Error("Could not acquire db connection from pool", "error", err)
 			return
 		}
 		defer conn.Release()

--- a/componentsHandler.go
+++ b/componentsHandler.go
@@ -13,7 +13,7 @@ var componentsHandlers = map[string]func(s *discordgo.Session, i *discordgo.Inte
 		roleId := rolesData.GetRoleByName(roleString).Id
 		conn, err := pool.Acquire(context.Background())
 		if err != nil {
-			log.Error("Could not aquire db connection from pool", "error", err)
+			log.Error("Could not acquire db connection from pool", "error", err)
 			return
 		}
 		defer conn.Release()
@@ -79,7 +79,6 @@ var componentsHandlers = map[string]func(s *discordgo.Session, i *discordgo.Inte
 			},
 		})
 	},
-	
 }
 
 func setWeapon(s *discordgo.Session, i *discordgo.InteractionCreate, weapon string) {
@@ -87,7 +86,7 @@ func setWeapon(s *discordgo.Session, i *discordgo.InteractionCreate, weapon stri
 	wepId := weaponsData.GetWeaponByName(weaponString).Id
 	conn, err := pool.Acquire(context.Background())
 	if err != nil {
-		log.Error("Could not aquire db connection from pool", "error", err)
+		log.Error("Could not acquire db connection from pool", "error", err)
 		return
 	}
 	defer conn.Release()

--- a/discordHooks.go
+++ b/discordHooks.go
@@ -36,19 +36,19 @@ func registerHooks(s *discordgo.Session) {
 	s.AddHandler(func(s *discordgo.Session, i *discordgo.GuildMemberAdd) {
 		conn, err := pool.Acquire(context.Background())
 		if err != nil {
-			log.Error("Could not aquire db connection from pool", "error", err)
+			log.Error("Could not acquire db connection from pool", "error", err)
 		}
 		defer conn.Release()
 		CreateOrUpdateMember(conn.Conn(), i.Member, i.GuildID)
 
 	})
 	s.AddHandler(func(s *discordgo.Session, i *discordgo.GuildMemberRemove) {
-		SetMemberInactive(i.Member,i.GuildID)
+		SetMemberInactive(i.Member, i.GuildID)
 	})
 	s.AddHandler(func(s *discordgo.Session, i *discordgo.GuildMemberUpdate) {
 		conn, err := pool.Acquire(context.Background())
 		if err != nil {
-			log.Error("Could not aquire db connection from pool", "error", err)
+			log.Error("Could not acquire db connection from pool", "error", err)
 		}
 		defer conn.Release()
 		CreateOrUpdateMember(conn.Conn(), i.Member, i.GuildID)

--- a/modalHandler.go
+++ b/modalHandler.go
@@ -62,7 +62,7 @@ var modalHandlers = map[string]func(s *discordgo.Session, i *discordgo.Interacti
 		conn, err := pool.Acquire(context.Background())
 
 		if err != nil {
-			log.Error("Cannot aquire DB connection", "error", err)
+			log.Error("Cannot acquire DB connection", "error", err)
 			return
 		}
 		startDate, err := parseDateTime(date, time)


### PR DESCRIPTION
## Summary
- replace misspelled "aquire" with "acquire" in various log statements

## Testing
- `go build` *(fails: command hung, interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_689b2e67a87c832e933df761503b96f1