### PR TITLE
Fix event date placeholder

### DIFF
--- a/commandHandler.go
+++ b/commandHandler.go
@@ -281,7 +281,7 @@ func createEvent(s *discordgo.Session, i *discordgo.InteractionCreate) {
 							CustomID:    "event_date",
 							Label:       "Event date",
 							Style:       discordgo.TextInputShort,
-							Placeholder: "Enter event date (DD-MM-YYY)",
+							Placeholder: "Enter event date (DD-MM-YYYY)",
 							MinLength:   10,
 							MaxLength:   10,
 							Required:    true,


### PR DESCRIPTION
## Summary
- fix event date modal placeholder using four digit year format

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b2e73081c832e8ace05d7252a3952