### PR TITLE
Add tests for parseDateTime utility function

### DIFF
--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseDateTimeValid(t *testing.T) {
+	dateStr := "27-05-2024"
+	timeStr := "14:30"
+
+	got, err := parseDateTime(dateStr, timeStr)
+	if err != nil {
+		t.Fatalf("parseDateTime returned error: %v", err)
+	}
+
+	loc, err := time.LoadLocation("Europe/Prague")
+	if err != nil {
+		t.Fatalf("failed to load location: %v", err)
+	}
+
+	want := time.Date(2024, time.May, 27, 14, 30, 0, 0, loc)
+	if !got.Equal(want) {
+		t.Errorf("expected %v, got %v", want, got)
+	}
+}
+
+func TestParseDateTimeInvalid(t *testing.T) {
+	_, err := parseDateTime("2024/05/27", "14:30")
+	if err == nil {
+		t.Fatalf("expected error for invalid date format, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- add util_test.go with tests for parseDateTime valid and invalid inputs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689b2e759058832ea38c5627c5141ffe