### PR TITLE
Add game role management commands and database support

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -51,10 +51,10 @@ var commands = []*discordgo.ApplicationCommand{
 			},
 		},
 	},
-	{
+	/*	{
 		Name:        "set-gear",
 		Description: "Set your gear and CP",
-	},
+	},*/
 	{
 		Name:        "notifications",
 		Description: "Enable or disable notifications",
@@ -92,6 +92,33 @@ var commands = []*discordgo.ApplicationCommand{
 				Type:        discordgo.ApplicationCommandOptionString,
 				Name:        "guild-id",
 				Description: "Guild ID",
+				Required:    true,
+			},
+		},
+	},
+	{
+		Name: "add-game-role",
+		Type: discordgo.UserApplicationCommand,
+	},
+	{
+		Name: "remove-game-role",
+		Type: discordgo.UserApplicationCommand,
+	},
+	{
+		Name:        "set_game_roles",
+		Description: "Set game roles for server",
+		DefaultMemberPermissions: &serverAdminPermission,
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionRole,
+				Name:        "role",
+				Description: "Role to set",
+				Required:    true,
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionRole,
+				Name:        "leader_role",
+				Description: "Role to set as leader",
 				Required:    true,
 			},
 		},

--- a/migrations/1_guilds_table.sql
+++ b/migrations/1_guilds_table.sql
@@ -2,5 +2,7 @@ CREATE TABLE guilds (
     id BIGINT PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     api_user VARCHAR(255) NULL,
-    api_key VARCHAR(255) NULL
+    api_key VARCHAR(255) NULL,
+    game_role VARCHAR(255) NULL,
+    game_leader_role VARCHAR(255) NULL
 );

--- a/util.go
+++ b/util.go
@@ -58,3 +58,15 @@ func parseDateTime(dateStr, timeStr string) (time.Time, error) {
 	layout := "02-01-2006 15:04"
 	return time.ParseInLocation(layout, combined, loc)
 }
+
+func stringPtr(s string) *string {
+	return &s
+}
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
- Implemented commands for adding and removing game roles.
- Added a command to set game roles for a server with appropriate permissions.
- Updated the guilds table to include game_role and game_leader_role fields.
- Introduced utility functions for string pointer handling and slice checking.

feat: Allow adding and removing T&L role for leader role
Fixes #1